### PR TITLE
feat: add youtube live stream URL support, add extra parsing option for instagram reels

### DIFF
--- a/src/siteContentRules.ts
+++ b/src/siteContentRules.ts
@@ -1449,7 +1449,7 @@ export const siteContentRules: {
     domain: 'instagram.com',
     extractContentInfo: createIdFromFirstPathnameRegexMatchContentInfoExtractor(
       'reelId',
-      /^\/reel\/(\w+)/u,
+      /^(?:\/[\w-]+\/reel\/|\/reel\/)(\w+)/u,
       'https://instagram.com/reel/{{reelId}}',
     ),
     formatUrl: ({ reelId }) => {
@@ -1457,6 +1457,10 @@ export const siteContentRules: {
     },
     site: 'INSTAGRAM',
     tests: {
+      'https://www.instagram.com/instagram/reel/DQuQGP_AO70': {
+        reelId: 'DQuQGP_AO70',
+        url: 'https://instagram.com/reel/DQuQGP_AO70',
+      },
       'https://www.instagram.com/reel/Cbz20_0j2m4/': {
         reelId: 'Cbz20_0j2m4',
         url: 'https://instagram.com/reel/Cbz20_0j2m4',

--- a/src/siteContentRules.ts
+++ b/src/siteContentRules.ts
@@ -516,6 +516,13 @@ export type SiteContentInfo = {
     url: string;
     urlVariant: 'FOLDER';
   };
+  'YOUTUBE.LIVE_VIDEO.DEFAULT': {
+    contentType: 'LIVE_VIDEO';
+    site: 'YOUTUBE';
+    url: string;
+    urlVariant: 'DEFAULT';
+    videoId: string;
+  };
   'YOUTUBE.PLAYLIST.DEFAULT': {
     contentType: 'PLAYLIST';
     playlistId: string;
@@ -2323,6 +2330,31 @@ export const siteContentRules: {
       },
     },
     urlVariant: 'FOLDER',
+    weight: 100,
+  },
+  'YOUTUBE.LIVE_VIDEO.DEFAULT': {
+    contentType: 'LIVE_VIDEO',
+    domain: /(^|\.)youtube\.com$/u,
+    extractContentInfo: createIdFromFirstPathnameRegexMatchContentInfoExtractor(
+      'videoId',
+      /^\/live\/([\w-]+)/u,
+      'https://youtube.com/live/{{videoId}}',
+    ),
+    formatUrl: ({ videoId }) => {
+      return `https://youtube.com/live/${videoId}`;
+    },
+    site: 'YOUTUBE',
+    tests: {
+      'https://www.youtube.com/live/dQw4w9WgXcQ': {
+        url: 'https://youtube.com/live/dQw4w9WgXcQ',
+        videoId: 'dQw4w9WgXcQ',
+      },
+      'https://youtube.com/live/dQw4w9WgXcQ': {
+        url: 'https://youtube.com/live/dQw4w9WgXcQ',
+        videoId: 'dQw4w9WgXcQ',
+      },
+    },
+    urlVariant: 'DEFAULT',
     weight: 100,
   },
   'YOUTUBE.PLAYLIST.DEFAULT': {


### PR DESCRIPTION
## Summary
This PR includes two improvements to the semantic URL parser: 
- a fix for Instagram Reels URL parsing 
- Support for YouTube Live URLs.

## Changes

### Fix: Instagram Reels URL Parsing
- **Issue**: The parser was unable to handle Instagram Reels URLs that include account names in the path (e.g., `instagram.com/instagram/reel/DQuQGP_AO70`)
- **Solution**: Updated the regex pattern to support both URL formats:
  - With account name: `/instagram/reel/{reelId}`
  - Without account name: `/reel/{reelId}`
- **Changes**: Modified the regex pattern in `INSTAGRAM.VIDEO.REEL` rule from `/^\/reel\/(\w+)/u` to `/^(?:\/[\w-]+\/reel\/|\/reel\/)(\w+)/u`, to handle both valid URLs.
- **Testing**: Added test case for the account name variant

### Feature: YouTube Live URL Support
- **Enhancement**: Added support for parsing and formatting YouTube Live URLs
- **Implementation**: 
  - Added new `YOUTUBE.VIDEO.LIVE` content type to type definitions
  - Created new rule in `siteContentRules` to handle URLs matching `youtube.com/live/{videoId}`
  - Includes content info extractor, URL formatter, and test cases
- **Testing**: Added test cases for both `www.youtube.com` and `youtube.com` domain variants
